### PR TITLE
Add xtask to project

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ Cargo.lock
 
 # CMake build files
 build/
+# ccache
+.cache
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "zint-wasm-sys/zint"]
 	path = zint-wasm-sys/zint
 	url = https://github.com/zint/zint
+[submodule "zint-typst-plugin/vendor/wasm-minimal-protocol"]
+	path = zint-typst-plugin/vendor/wasm-minimal-protocol
+	url = git@github.com:Caellian/wasm-minimal-protocol.git
+	branch = zint-wasi-vendor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,21 @@
 [workspace]
 package.edition = "2021"
+package.license = "MIT"
 resolver = "2"
 members = [
     "zint-wasm-sys",
     "zint-wasm-rs",
-    "zint-typst-plugin"
+    "zint-typst-plugin",
+    "zint-typst-plugin/vendor/wasm-minimal-protocol/crates/macro",
+    "zint-typst-plugin/vendor/wasm-minimal-protocol/crates/wasi-stub",
+    "xtask"
 ]
-package.license = "MIT"
+default-members = [
+    "zint-wasm-sys",
+    "zint-wasm-rs",
+    "zint-typst-plugin",
+]
+
 [profile.release]
 lto = true          # Enable link-time optimization
 strip = true        # Strip symbols from binary*

--- a/README.md
+++ b/README.md
@@ -20,11 +20,20 @@ _(click on the image to open)_
 
 ## Build
 
-Install wasi-sdk. Put them at `/opt/wasi-sdk`. Then run:
-
-
+Clone with:
+```sh
+git clone --recurse-submodules -j8 https://github.com/Enter-tainer/zint-wasi.git
 ```
-./build.sh
+
+You must have standard development tools pre-installed on your machine and in path:
+- cargo (rustc; get with [rustup](https://rustup.rs/))
+- tar
+- wget/curl
+- gcc/clang
+
+To build the typst package, run:
+```sh
+cargo xtask package
 ```
 
 ## License

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+# should be as minimal as possible with as few transient dependencies as
+# possible, prefer using system tools instead

--- a/xtask/src/action.rs
+++ b/xtask/src/action.rs
@@ -1,0 +1,234 @@
+use crate::*;
+use std::{collections::HashSet, fmt::Display};
+use std::io;
+
+/*
+OptPlugin, // wasm-opt typst-package/zint_typst_plugin.wasm -O3 --enable-bulk-memory -o typst-package/zint_typst_plugin.wasm
+*/
+
+// hidden for readability
+include!("./action_macros.rs");
+
+// - if `arg` is empty, action can't be ran from xtask command
+// - if `name` is empty, action exectuion will be hidden
+declare_actions![
+    EnsureWasi: {
+        arg: "", name: "prepare WASI SDK",
+        require: [],
+        run: Some(crate::actions::action_ensure_wasi_sdk)
+    },
+    StubPlugin: {
+        arg: "", name: "stub wasi",
+        require: [BuildPlugin],
+        run: Some(crate::actions::action_stub_plugin)
+    },
+    EnsureWasmOpt: {
+        arg: "", name: "prepare wasm-opt",
+        require: [],
+        run: Some(crate::actions::action_prepare_wasm_opt)
+    },
+    OptPlugin: {
+        arg: "", name: "optimize wasm",
+        require: [StubPlugin],
+        run: Some(crate::actions::action_opt_plugin)
+    },
+    BuildPlugin: {
+        arg: "build-plugin", name: "build plugin",
+        require: [EnsureWasi],
+        run: Some(crate::actions::action_build_plugin)
+    },
+    PackagePlugin: {
+        arg: "package-plugin", name: "package plugin",
+        require: [StubPlugin, OptPlugin],
+        run: None
+    },
+    CopyLicense: {
+        arg: "", name: "",
+        require: [],
+        run: Some(crate::actions::action_copy_license)
+    },
+    Package: {
+        arg: "package", name: "package",
+        require: [PackagePlugin, CopyLicense],
+        run: None
+    },
+    All: {
+        arg: "all", name: "",
+        require: [Package],
+        run: None
+    },
+];
+use Action::*;
+
+impl Action {
+    fn run_impl(self, executed: &mut HashSet<Self>, running: &mut Vec<Self>) -> ActionResult {
+        if running.contains(&self) {
+            let names: Vec<_> = running
+                .iter()
+                .chain([&self])
+                .map(|it| format!("{:?}", it))
+                .collect();
+            let names = names.join(">");
+            unreachable!("action dependency cycle in path: {}", names)
+        }
+        running.push(self);
+
+        if executed.contains(&self) {
+            action_skip!("already executed");
+        }
+
+        for dep in self.dependencies() {
+            action_try!(dep.run_impl(executed, running));
+        }
+
+        let result = if let Some(runner) = self.runner() {
+            if let Some(name) = self.name() {
+                println!("[TASK]: {name}")
+            }
+            let result = (runner)();
+            match &result {
+                ActionResult::Ok => println!("[OK]"),
+                ActionResult::Skip { reason: None } => println!("[SKIPPED]"),
+                ActionResult::Skip {
+                    reason: Some(reason),
+                } => {
+                    println!("[SKIPPED]: {reason}");
+                }
+                ActionResult::Error(error) => {
+                    println!("[ERROR]: {error}");
+                    std::process::exit(1);
+                }
+            }
+            result
+        } else {
+            ActionResult::Ok
+        };
+
+        executed.insert(self);
+        running.pop();
+
+        result
+    }
+
+    #[inline]
+    pub fn run(self, executed: &mut HashSet<Self>) -> io::Result<()> {
+        let mut running = Vec::with_capacity(8);
+        if let ActionResult::Error(error) = self.run_impl(executed, &mut running) {
+            Err(io::Error::new(io::ErrorKind::Other, error))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.name() {
+            Some(name) => f.write_str(name),
+            None => write!(f, "{:?}", self),
+        }
+    }
+}
+
+pub enum ActionResult {
+    Ok,
+    Skip { reason: Option<String> },
+    Error(Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+impl ActionResult {
+    #[inline]
+    pub fn error<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        ActionResult::Error(Box::new(error))
+    }
+}
+
+pub mod macros {
+    #[macro_export]
+    macro_rules! action_ok {
+        () => {
+            return $crate::action::ActionResult::Ok;
+        };
+    }
+    #[macro_export]
+    macro_rules! action_skip {
+        () => {
+            return $crate::action::ActionResult::Skip {
+                reason: None
+            }
+        };
+        ($reason: literal) => {
+            return $crate::action::ActionResult::Skip {
+                reason: Some($reason.to_string())
+            }
+        };
+        ($reason: literal, $($arg: expr),+) => {
+            return $crate::action::ActionResult::Skip {
+                reason: Some(format!($reason, $($arg),+))
+            }
+        };
+    }
+    #[macro_export]
+    macro_rules! action_error {
+        ($error: expr) => {
+            return $crate::action::ActionResult::error($error)
+        };
+    }
+    #[macro_export]
+    macro_rules! action_expect {
+        ($stmt: expr) => {{
+            match $stmt {
+                Ok(it) => it,
+                Err(error) => $crate::action_error!(error),
+            }
+        }};
+    }
+    #[macro_export]
+    macro_rules! action_expect_0 {
+        (cargo([$($args: expr),*])) => {{
+            $crate::action_expect!($crate::tools::CommandError::from_exit(
+                $crate::action_expect!(cargo([$($args),*]))
+            ).map_err(|err| err.program("cargo")))
+        }};
+        (cmd($name: literal, [$($args: expr),*])) => {{
+            $crate::action_expect!($crate::tools::CommandError::from_exit(
+                $crate::action_expect!(cmd($name, [$($args),*]))
+            ).map_err(|err| err.program($name)))
+        }};
+        (cmd($program: literal as $name: literal, [$($args: expr),*])) => {{
+            $crate::action_expect!($crate::tools::CommandError::from_exit(
+                $crate::action_expect!(cmd($program, [$($args),*]))
+            ).map_err(|err| err.program($name)))
+        }};
+        (cmd($name: literal, [$($args: expr),*])) => {{
+            $crate::action_expect!($crate::tools::CommandError::from_exit(
+                $crate::action_expect!(cmd($name, [$($args),*]))
+            ).map_err(|err| err.program(stringify!($name))))
+        }};
+        (cmd($program: ident as $name: literal, [$($args: expr),*])) => {{
+            $crate::action_expect!($crate::tools::CommandError::from_exit(
+                $crate::action_expect!(cmd($program, [$($args),*]))
+            ).map_err(|err| err.program($name)))
+        }};
+        ($stmt: expr) => {{
+            $crate::action_expect!($crate::tools::CommandError::from_exit(
+                $crate::action_expect!($stmt)
+            ))
+        }};
+    }
+    #[macro_export]
+    macro_rules! action_try {
+        ($stmt: expr) => {{
+            if let $crate::action::ActionResult::Error(error) = $stmt {
+                return $crate::action::ActionResult::Error(error);
+            }
+        }};
+    }
+
+    #[allow(unused_imports)]
+    pub use crate::{
+        action_error, action_expect, action_expect_0, action_ok, action_skip, action_try,
+    };
+}

--- a/xtask/src/action_macros.rs
+++ b/xtask/src/action_macros.rs
@@ -1,0 +1,56 @@
+macro_rules! declare_actions {
+    ($($action: ident: {arg: $arg: literal, name: $name: literal, require: [$($dep: ident),* $(,)?], run: $runner: expr}),+ $(,)?) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum Action {
+            $($action,)*
+        }
+
+        impl Action {
+            /// Used for displaying current step when running commands
+            ///
+            /// If `None` is returned, then the action won't be displayed when it's run.
+            pub fn name(self) -> Option<&'static str> {
+                let parsed = [
+                    $((Self::$action, $name),)*
+                ];
+                parsed.into_iter()
+                    .filter(|(_, name)| !name.is_empty())
+                    .find_map(|(action, name)| if action == self {
+                        Some(name)
+                    } else {
+                        None
+                    })
+            }
+
+            /// Tries parsing argument string into an `Action`.
+            /// Returns the input argument on failiure.
+            pub fn parse_arg(argument: impl AsRef<str>) -> Result<Self, String> {
+                let parsed = [
+                    $(($arg, Self::$action),)*
+                ];
+                parsed.into_iter()
+                    .filter(|(cmd, _)| !cmd.is_empty())
+                    .find_map(|(cmd, action)| if cmd == argument.as_ref() {
+                        Some(action)
+                    } else {
+                        None
+                    })
+                    .ok_or_else(|| argument.as_ref().to_string())
+            }
+
+            /// Provides a list of dependencies for each action.
+            pub fn dependencies(self) -> &'static [Self] {
+                match self {
+                    $($action => &[$(Self::$dep),*],)*
+                }
+            }
+
+            /// Provides optionally executed logic by an action.
+            pub fn runner(self) -> Option<fn() -> ActionResult> {
+                match self {
+                    $(Self::$action => $runner,)*
+                }
+            }
+        }
+    };
+}

--- a/xtask/src/actions.rs
+++ b/xtask/src/actions.rs
@@ -1,0 +1,143 @@
+use std::path::{Path, PathBuf};
+
+use crate::action::macros::*;
+use crate::action::ActionResult;
+use crate::tools::*;
+use crate::{state, state_path};
+
+const WASI_PATH_VAR: &str = "WASI_SDK_PATH";
+
+fn has_wasi_sdk() -> bool {
+    match std::env::var(WASI_PATH_VAR) {
+        Ok(it) => exists(it),
+        Err(_) => false,
+    }
+}
+
+#[allow(unreachable_code)]
+fn wasi_url(version: impl AsRef<str>) -> String {
+    let version = version.as_ref();
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    return format!("https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-{version}/wasi-sdk-{version}.0-arm64-linux.tar.gz");
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    return format!("https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-{version}/wasi-sdk-{version}.0-x86_64-linux.tar.gz");
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    return format!("https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-{version}/wasi-sdk-{version}.0-arm64-macos.tar.gz");
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    return format!("https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-{version}/wasi-sdk-{version}.0-x86_64-macos.tar.gz");
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    return format!("https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-{version}/wasi-sdk-{version}.0-x86_64-windows.tar.gz");
+    panic!("no prebuild WASI SDK available for current platform; please build and specify `WASI_SDK_PATH` environment variable manually")
+}
+
+pub fn action_ensure_wasi_sdk() -> ActionResult {
+    if has_wasi_sdk() {
+        action_skip!("WASI SDK is set with environment variable");
+    }
+
+    let work_dir = state_path!(WORK_DIR);
+    let download_path = work_dir.join("wasi_sdk.tar.gz");
+    let extract_path = match std::env::var(WASI_PATH_VAR) {
+        Ok(it) if !it.is_empty() => PathBuf::from(it),
+        _ => work_dir.join("wasi_sdk"),
+    };
+
+    if !exists(&extract_path) {
+        if !exists(&download_path) {
+            let url = wasi_url(state!(WASI_SDK_VERSION, default: "24"));
+            action_expect!(download(url, &download_path));
+        }
+
+        let _ = std::fs::create_dir_all(&extract_path);
+        action_expect!(untar(
+            download_path,
+            &extract_path,
+            ["--strip-components=1"]
+        ));
+    }
+
+    let wasi_sdk_path = action_expect!(extract_path.canonicalize());
+
+    unsafe {
+        std::env::set_var(WASI_PATH_VAR, wasi_sdk_path);
+    }
+
+    action_ok!();
+}
+
+pub fn action_build_plugin() -> ActionResult {
+    action_expect_0!(cargo(["build", "--release", "--target", "wasm32-wasip1"]));
+    action_ok!();
+}
+
+pub fn action_stub_plugin() -> ActionResult {
+    let base_path = state_path!(WORK_DIR).join("release");
+    let release = base_path.join(state!(PLUGIN_WASM));
+    let stubbed = base_path.join(state!(PLUGIN_STUB_WASM, default: "plugin_stub.wasm"));
+    action_expect!(wasi_stub(release, stubbed));
+    action_ok!();
+}
+
+#[allow(unreachable_code)]
+fn binaryen_url(version: impl AsRef<str>) -> String {
+    let version = version.as_ref();
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    return format!("https://github.com/WebAssembly/binaryen/releases/download/version_{version}/binaryen-version_{version}-arm64-linux.tar.gz");
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    return format!("https://github.com/WebAssembly/binaryen/releases/download/version_{version}/binaryen-version_{version}-x86_64-linux.tar.gz");
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    return format!("https://github.com/WebAssembly/binaryen/releases/download/version_{version}/binaryen-version_{version}-arm64-macos.tar.gz");
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    return format!("https://github.com/WebAssembly/binaryen/releases/download/version_{version}/binaryen-version_{version}-x86_64-macos.tar.gz");
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    return format!("https://github.com/WebAssembly/binaryen/releases/download/version_{version}/binaryen-version_{version}-x86_64-windows.tar.gz");
+    panic!("no prebuild binaryen available for current platform")
+}
+
+pub fn action_prepare_wasm_opt() -> ActionResult {
+    if has_command(WASM_OPT) {
+        action_ok!();
+    }
+
+    let work_dir = state_path!(WORK_DIR);
+    let binaryen_tar = work_dir.join("binaryen.tar.gz");
+    let wasm_opt_dir = work_dir.join("tools");
+    let wasm_opt_bin = wasm_opt_dir.join(WASM_OPT);
+    if !exists(wasm_opt_bin) {
+        if !exists(&binaryen_tar) {
+            action_expect!(download(
+                binaryen_url(state!(BINARYEN_VERSION, default: "119")),
+                &binaryen_tar
+            ));
+        }
+        action_expect!(untar(
+            binaryen_tar,
+            wasm_opt_dir,
+            [
+                "--strip-components".to_string(),
+                format!(
+                    "/binaryen-version_{}/bin/{WASM_OPT}",
+                    state!(BINARYEN_VERSION, default: "119")
+                )
+            ]
+        ));
+    }
+    action_ok!();
+}
+
+pub fn action_opt_plugin() -> ActionResult {
+    let base_path = state_path!(WORK_DIR).join("release");
+    let stub_path = base_path.join(state!(PLUGIN_STUB_WASM, default: "plugin_stub.wasm"));
+    let stub_opt_path = base_path.join(state!(PLUGIN_STUB_OPT_WASM, default: "plugin_stub_opt.wasm"));
+    action_expect!(wasm_opt(stub_path, &stub_opt_path));
+    let target_path = Path::new(state!(TYPST_PKG)).join(state!(PLUGIN_WASM_OUT, default: "plugin.wasm"));
+    action_expect!(std::fs::copy(stub_opt_path, target_path));
+    action_ok!();
+}
+
+pub fn action_copy_license() -> ActionResult {
+    let source_path = state_path!(LICENSE_FILE, default: "./LICENSE");
+    let target_path = Path::new(state!(TYPST_PKG)).join("LICENSE");
+    action_expect!(std::fs::copy(source_path, target_path));
+    action_ok!();
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,34 @@
+use std::{collections::HashSet, str::FromStr};
+
+use action::Action;
+
+mod action;
+mod actions;
+mod tools;
+mod state;
+
+fn main() {
+    let args = std::env::args().skip(1);
+
+    let actions: Result<Vec<Action>, String> =
+        args.into_iter().map(|it| Action::parse_arg(&it)).collect();
+    let mut actions = match actions {
+        Ok(it) => it,
+        Err(unknown) => {
+            println!("unknown action: {unknown}");
+            std::process::exit(1)
+        }
+    };
+
+    if actions.is_empty() {
+        println!("no actions specified, running 'all'");
+        actions.push(Action::All);
+    }
+
+    let mut executed = HashSet::new();
+    for action in actions {
+        if let Err(error) = action.run(&mut executed) {
+            println!("ERROR: {}", error)
+        }
+    }
+}

--- a/xtask/src/state.rs
+++ b/xtask/src/state.rs
@@ -1,0 +1,197 @@
+use std::collections::HashMap;
+use std::io::{self, BufRead as _, Write as _};
+use std::path::{Path, PathBuf};
+
+#[derive(Default)]
+pub struct State {
+    source: Option<PathBuf>,
+    items: HashMap<String, String>,
+    environment: HashMap<String, String>,
+}
+impl State {
+    pub fn global() -> StateAccess {
+        use std::sync::{Mutex, OnceLock};
+
+        const STATE_PATH: &str = "./xtask/state";
+        static STATE: OnceLock<Mutex<State>> = OnceLock::new();
+
+        let mutex = STATE.get_or_init(|| {
+            let value = match State::load(STATE_PATH) {
+                Ok(it) => it,
+                Err(not_found) if not_found.kind() == io::ErrorKind::NotFound => State::new(),
+                Err(other) => {
+                    eprintln!("{other}");
+                    std::process::abort()
+                }
+            };
+
+            Mutex::new(value)
+        });
+
+        let mutex = match mutex.try_lock() {
+            Ok(it) => it,
+            Err(std::sync::TryLockError::WouldBlock) => panic!("global state already locked"),
+            Err(std::sync::TryLockError::Poisoned(_)) => panic!("global state poisoned"),
+        };
+
+        StateAccess { mutex }
+    }
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn load(path: impl AsRef<Path>) -> io::Result<Self> {
+        let input = std::fs::File::open(path.as_ref()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("unable to find state file: {}", path.as_ref().display()),
+            )
+        })?;
+        let input = io::BufReader::new(input);
+
+        let items: Result<HashMap<String, String>, _> = input
+            .lines()
+            .enumerate()
+            .filter_map(|(i, line)| {
+                let Ok(line) = line else {
+                    return Some(line.map(|it| (i, it)));
+                };
+                let line = line.trim();
+                if line.starts_with('#') {
+                    return None;
+                }
+
+                Some(Ok((
+                    i,
+                    line.split_once('#')
+                        .map(|(expr, _)| expr.trim())
+                        .unwrap_or(line)
+                        .to_string(),
+                )))
+            })
+            .map(|it| {
+                it.and_then(|(i, line)| {
+                    line.split_once("=")
+                        .ok_or(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "{}:{i}: state variable doesn't contain '=' separator",
+                                path.as_ref().display()
+                            ),
+                        ))
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                })
+            })
+            .collect();
+
+        let items = items?;
+        let mut environment = HashMap::new();
+        for (key, val) in std::env::vars() {
+            if let Some(key) = key.strip_prefix("XTASK_") {
+                environment.insert(key.to_string(), val);
+            }
+        }
+
+        Ok(Self {
+            source: Some(path.as_ref().to_path_buf()),
+            items,
+            environment,
+        })
+    }
+    pub fn save(&self, path: impl AsRef<Path>) -> io::Result<()> {
+        let output = std::fs::File::create(path.as_ref())?;
+        let mut output = io::BufWriter::new(output);
+        for (k, v) in &self.items {
+            output.write_all(k.as_bytes())?;
+            output.write_all(b"=")?;
+            output.write_all(v.as_bytes())?;
+            output.write_all(b"\n")?;
+        }
+        output.flush()
+    }
+    pub fn get(&self, key: impl AsRef<str>) -> Option<&str> {
+        self.items
+            .get(key.as_ref())
+            .map(|it| it.as_str())
+            .or_else(|| self.environment.get(key.as_ref()).map(|it| it.as_str()))
+    }
+    pub fn set(&mut self, key: impl AsRef<str>, value: impl AsRef<str>) {
+        self.items
+            .insert(key.as_ref().to_string(), value.as_ref().to_string());
+    }
+}
+
+impl Drop for State {
+    fn drop(&mut self) {
+        if let Some(source) = &self.source {
+            if self.save(source).is_err() {
+                eprintln!("unable to update xtask state file: {}", source.display())
+            }
+        }
+    }
+}
+
+impl<S> std::ops::Index<S> for State
+where
+    S: AsRef<str>,
+{
+    type Output = str;
+
+    fn index(&self, index: S) -> &Self::Output {
+        self.items
+            .get(index.as_ref())
+            .expect("state is missing expected entry")
+    }
+}
+
+#[macro_export]
+macro_rules! state {
+    ($key: tt) => {
+        $crate::state::State::global()
+            .get(stringify!($key))
+            .expect(concat!["state is missing '", stringify!($key), "' key"])
+    };
+    ($key: tt, default: $default: literal) => {
+        $crate::state::State::global()
+            .get(stringify!($key))
+            .unwrap_or($default)
+    };
+    ($key: literal, default: || $else: block) => {
+        $crate::state::State::global()
+            .get(stringify!($key))
+            .unwrap_or_else(|| $else)
+    };
+}
+#[macro_export]
+macro_rules! state_path {
+    ($key: tt) => {
+        std::path::PathBuf::from($crate::state!($key))
+    };
+    ($key: tt, default: $default: literal) => {
+        std::path::PathBuf::from($crate::state!($key, default: $default))
+    };
+    ($key: literal, default: || $else: block) => {
+        std::path::PathBuf::from($crate::state!($key, default: || $else))
+    };
+}
+
+mod _impl {
+    use super::*;
+    use std::sync::MutexGuard;
+
+    pub struct StateAccess {
+        pub(super) mutex: MutexGuard<'static, State>,
+    }
+    impl std::ops::Deref for StateAccess {
+        type Target = State;
+
+        fn deref(&self) -> &Self::Target {
+            &self.mutex
+        }
+    }
+    impl std::ops::DerefMut for StateAccess {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.mutex
+        }
+    }
+}
+use _impl::*;

--- a/xtask/src/tools.rs
+++ b/xtask/src/tools.rs
@@ -1,0 +1,544 @@
+use std::{
+    ffi::{OsStr, OsString},
+    fmt::{Debug, Display},
+    io,
+    path::Path,
+    process as proc,
+    sync::{Once, OnceLock},
+};
+
+use crate::state_path;
+
+pub fn exists(path: impl AsRef<Path>) -> bool {
+    std::fs::exists(path.as_ref()).ok().unwrap_or_default()
+}
+
+pub fn cmd<S: AsRef<OsStr>>(
+    program: impl AsRef<OsStr>,
+    args: impl IntoIterator<Item = S>,
+) -> proc::Command {
+    let mut result = proc::Command::new(program.as_ref());
+    result.args(args);
+    result
+}
+
+/* USE: path.canonicalize()
+pub fn realpath(path: impl AsRef<Path>) -> io::Result<PathBuf> {
+    cmd("realpath", [path.as_ref()]).output().map(|it| PathBuf::from(OsString::from_vec(it.stdout)))
+}
+*/
+
+pub fn has_command(name: impl AsRef<OsStr>) -> bool {
+    let which = if cfg!(target_os = "windows") {
+        "where"
+    } else {
+        "which"
+    };
+    let output = match cmd(which, [name]).output() {
+        Ok(it) => it,
+        Err(_) => panic!("can't run '{}' to check evirnoment", which),
+    };
+    output.status.success() && !output.stdout.is_empty()
+}
+
+pub fn cargo<S: AsRef<OsStr>>(args: impl IntoIterator<Item = S>) -> io::Result<proc::ExitStatus> {
+    cmd("cargo", args)
+        //.env("WASI_SDK_PATH", "./target/wasi_sdk")
+        .status()
+}
+
+#[cfg(target_os = "windows")]
+pub fn run_powershell<S: AsRef<str>>(
+    code: impl IntoIterator<Item = S>,
+) -> io::Result<proc::ExitStatus> {
+    // not tested
+    let mut ps = proc::Command::new("powershell")
+        .args(["-Command", "-"])
+        .spawn()
+        .expect("unable to run powershell");
+    let mut stdin = ps.stdin.take().expect("can't pipe to powershell");
+    for line in code.into_iter() {
+        stdin
+            .write_all(line.as_ref().as_bytes())
+            .expect("can't write commands to powershell");
+        stdin
+            .write_all(b"\n")
+            .expect("can't write commands to powershell");
+    }
+    stdin
+        .write_all(b"exit\n")
+        .expect("can't terminate powershell");
+    ps.wait()
+}
+
+#[cfg(not(target_os = "windows"))]
+const WGET: &str = "wget";
+#[cfg(target_os = "windows")]
+const WGET: &str = "wget.exe";
+#[cfg(not(target_os = "windows"))]
+const CURL: &str = "curl";
+#[cfg(target_os = "windows")]
+const CURL: &str = "curl.exe";
+
+fn download_wget(url: &str, path: &Path) -> Result<(), DownloadError> {
+    let status = cmd(
+        WGET,
+        [
+            OsStr::new(url),
+            OsStr::new("-q"),
+            OsStr::new("--show-progress"),
+            OsStr::new("-O"),
+            path.as_os_str(),
+        ],
+    )
+    .status()
+    .map_err(DownloadError::IO)?;
+    // https://www.gnu.org/software/wget/manual/html_node/Exit-Status.html
+    match status.code() {
+        Some(0) => Ok(()),
+        Some(3) => Err(DownloadError::IO(io::Error::new(
+            io::ErrorKind::Other,
+            format!("file I/O error: {}", path.display()),
+        ))),
+        Some(4) => Err(DownloadError::BadUrl {
+            url: url.to_string(),
+        }),
+        _ => Err(DownloadError::CommandError(
+            CommandError::from(status).program(WGET),
+        )),
+    }
+}
+fn download_curl(url: &str, path: &Path) -> Result<(), DownloadError> {
+    let status = cmd(
+        CURL,
+        [
+            OsStr::new("-L"),
+            OsStr::new(url),
+            OsStr::new("--output"),
+            path.as_os_str(),
+        ],
+    )
+    .status()
+    .map_err(DownloadError::IO)?;
+
+    // https://everything.curl.dev/cmdline/exitcode.html
+    match status.code() {
+        Some(0) => Ok(()),
+        Some(3) | Some(5) | Some(6) | Some(7) => Err(DownloadError::BadUrl {
+            url: url.to_string(),
+        }),
+        Some(23) => Err(DownloadError::IO(io::Error::new(
+            io::ErrorKind::Other,
+            format!("file I/O error: {}", path.display()),
+        ))),
+        _ => Err(DownloadError::CommandError(
+            CommandError::from(status).program(CURL),
+        )),
+    }
+}
+
+pub fn download(url: impl AsRef<str>, target: impl AsRef<Path>) -> Result<(), DownloadError> {
+    #[allow(clippy::type_complexity)]
+    static EXECUTOR: OnceLock<fn(&str, &Path) -> Result<(), DownloadError>> = OnceLock::new();
+    let run = EXECUTOR.get_or_init(|| {
+        if has_command(WGET) {
+            return download_wget;
+        }
+        if has_command(CURL) {
+            return download_curl;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // untested code from SO
+            return |url, path| {
+                run_powershell([
+                    "$client = new-object System.Net.WebClient".to_string(),
+                    format!("$client.DownloadFile(\"{url}\",\"{path}\")"),
+                ])
+            };
+        }
+        panic!("no supported program that can download files is present")
+    });
+    println!(
+        "\t- downloading '{}' to '{}'",
+        url.as_ref(),
+        target.as_ref().display()
+    );
+    run(url.as_ref(), target.as_ref())
+}
+
+#[derive(Debug)]
+pub enum DownloadError {
+    CommandError(CommandError),
+    BadUrl { url: String },
+    IO(io::Error),
+}
+impl std::fmt::Display for DownloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DownloadError::CommandError(exit) => std::fmt::Display::fmt(exit, f),
+            DownloadError::BadUrl { url } => write!(f, "can't resolve url: '{url}'"),
+            DownloadError::IO(io) => write!(f, "io error: {io}"),
+        }
+    }
+}
+impl std::error::Error for DownloadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CommandError(source) => Some(source),
+            Self::IO(source) => Some(source),
+            _ => None,
+        }
+    }
+}
+
+const TAR: &str = "tar";
+pub fn untar<S>(
+    archive: impl AsRef<Path>,
+    target: impl AsRef<Path>,
+    args: impl IntoIterator<Item = S>,
+) -> io::Result<()>
+where
+    S: AsRef<OsStr>,
+{
+    static CHECK: Once = Once::new();
+    CHECK.call_once(|| {
+        if !has_command(TAR) {
+            panic!("missing `tar` command in path")
+        }
+    });
+
+    println!(
+        "\t- extracting '{}' into '{}'",
+        archive.as_ref().display(),
+        target.as_ref().display()
+    );
+    let status = cmd(
+        TAR,
+        [
+            OsStr::new("-xsf"),
+            OsStr::new(archive.as_ref().as_os_str()),
+            OsStr::new("-C"),
+            OsStr::new(target.as_ref().as_os_str()),
+        ]
+        .into_iter()
+        .map(|it| it.to_os_string())
+        .chain(args.into_iter().map(|it| it.as_ref().to_os_string())),
+    )
+    .status()?;
+
+    match status.code() {
+        Some(0) => Ok(()),
+        None => Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "tar process interrupted",
+        )),
+        Some(other) => Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("tar exited with code #{other}"),
+        )),
+    }
+}
+
+type WasiStubRunner =
+    Box<dyn Fn(&Path, &Path) -> io::Result<proc::ExitStatus> + Send + Sync + 'static>;
+#[inline(always)]
+fn wasi_stub_runner(executable: impl AsRef<OsStr>) -> WasiStubRunner {
+    let executable = Box::leak(Box::new(executable.as_ref().to_os_string()));
+    Box::new(move |file: &Path, output: &Path| {
+        let r = OsString::from("-r");
+        let zero = OsString::from("0");
+        let o = OsString::from("-o");
+        cmd(
+            executable.as_os_str(),
+            [
+                r.as_os_str(),
+                zero.as_os_str(),
+                file.as_os_str(),
+                o.as_os_str(),
+                output.as_os_str(),
+            ],
+        )
+        .status()
+    })
+}
+
+const WASI_STUB: &str = "wasi-stub";
+/// Tries running wasi-stub from PATH, then from `./target/release` dir, then
+/// from `./target/debug`, if all else fails, builds it with cargo.
+pub fn wasi_stub(file: impl AsRef<Path>, output: impl AsRef<Path>) -> Result<(), CommandError> {
+    static RUNNER: OnceLock<WasiStubRunner> = OnceLock::new();
+    let runner = RUNNER.get_or_init(|| {
+        if has_command(WASI_STUB) {
+            return wasi_stub_runner(WASI_STUB);
+        }
+
+        let work_dir = state_path!(WORK_DIR);
+        let try_prebuilt = |kind: &str| {
+            let executable_path = work_dir.join(kind).join(WASI_STUB);
+            if !exists(&executable_path) {
+                return None;
+            }
+            let executable_path = executable_path
+                .canonicalize()
+                .expect("unable to canonicalize path that exists");
+            return Some(wasi_stub_runner(executable_path));
+        };
+        if let Some(it) = try_prebuilt("release") {
+            return it;
+        }
+        if let Some(it) = try_prebuilt("debug") {
+            return it;
+        }
+
+        return Box::new(move |file: &Path, output: &Path| {
+            let run = OsString::from("run");
+            let release = OsString::from("--release");
+            let bin = OsString::from("--bin=wasi-stub");
+            let pass = OsString::from("--");
+            let r = OsString::from("-r");
+            let zero = OsString::from("0");
+            let o = OsString::from("-o");
+            cargo([
+                run.as_os_str(),
+                release.as_os_str(),
+                bin.as_os_str(),
+                pass.as_os_str(),
+                r.as_os_str(),
+                zero.as_os_str(),
+                file.as_os_str(),
+                o.as_os_str(),
+                output.as_os_str(),
+            ])
+        });
+    });
+
+    if !exists(&file) {
+        return Err(CommandError::file_not_found("input", &file).program(WASI_STUB));
+    }
+
+    CommandError::from_exit(match (runner)(file.as_ref(), output.as_ref()) {
+        Ok(it) => it,
+        Err(_) => panic!("unable to run {WASI_STUB}"),
+    })
+    .map_err(|err| err.program(WASI_STUB))
+}
+
+pub const WASM_OPT: &str = "wasm-opt";
+pub fn wasm_opt(file: impl AsRef<Path>, output: impl AsRef<Path>) -> Result<(), CommandError> {
+    static RUNNER: OnceLock<WasmOptRunner> = OnceLock::new();
+    type WasmOptRunner =
+        Box<dyn Fn(&Path, &Path) -> io::Result<proc::ExitStatus> + Send + Sync + 'static>;
+
+    let runner = RUNNER.get_or_init(|| {
+        let runner = |program: &OsStr| {
+            let program = OsString::from(program);
+            Box::new(move |file: &Path, output: &Path| {
+                let opt = OsString::from("-O3");
+                let bulk_mem = OsString::from("--enable-bulk-memory");
+                let o = OsString::from("-o");
+                cmd(
+                    &program,
+                    [
+                        file.as_os_str(),
+                        opt.as_os_str(),
+                        bulk_mem.as_os_str(),
+                        o.as_os_str(),
+                        output.as_os_str(),
+                    ],
+                )
+                .status()
+            })
+        };
+
+        if has_command(WASM_OPT) {
+            return runner(OsStr::new(WASM_OPT));
+        }
+
+        let tool_path = state_path!(WORK_DIR).join("tools").join(WASM_OPT);
+        if exists(&tool_path) {
+            return runner(tool_path.as_os_str());
+        }
+
+        // not really, checked more places, but this is easier to explain
+        panic!("unable to find {WASM_OPT} in PATH")
+    });
+
+    if !exists(&file) {
+        return Err(CommandError::file_not_found("input", &file).program(WASM_OPT));
+    }
+
+    CommandError::from_exit(match (runner)(file.as_ref(), output.as_ref()) {
+        Ok(it) => it,
+        Err(_) => panic!("unable to run {WASM_OPT}"),
+    })
+    .map_err(|err| err.program(WASM_OPT))
+}
+
+pub enum CommandError {
+    ExitError {
+        program: Option<&'static str>,
+        code: std::num::NonZeroI32,
+    },
+    Interrupted {
+        program: Option<&'static str>,
+        interrupt: i32,
+    },
+    BadArgument {
+        program: Option<&'static str>,
+        argument: &'static str,
+        expect_found: Option<(&'static str, Box<dyn Display + Send + Sync + 'static>)>,
+        reason: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    },
+}
+
+impl CommandError {
+    pub fn new(code: i32) -> Self {
+        assert!(code != 0, "exit code 0 doesn't indicate an error");
+        unsafe {
+            Self::ExitError {
+                program: None,
+                code: std::num::NonZeroI32::new_unchecked(code),
+            }
+        }
+    }
+    pub fn interrupt(interrupt: i32) -> Self {
+        Self::Interrupted {
+            program: None,
+            interrupt,
+        }
+    }
+    pub fn file_not_found(argument: &'static str, file: impl AsRef<Path>) -> Self {
+        Self::BadArgument {
+            program: None,
+            argument,
+            expect_found: None,
+            reason: Some(Box::new(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "file not found or inaccessible (path: '{}')",
+                    file.as_ref().display()
+                ),
+            ))),
+        }
+    }
+
+    pub fn program(mut self, name: &'static str) -> Self {
+        match &mut self {
+            CommandError::ExitError { program, .. } => *program = Some(name),
+            CommandError::Interrupted { program, .. } => *program = Some(name),
+            CommandError::BadArgument { program, .. } => *program = Some(name),
+        }
+        self
+    }
+
+    pub fn from_exit(exit: proc::ExitStatus) -> Result<(), Self> {
+        #[allow(unreachable_patterns)]
+        match exit.code() {
+            Some(0) => Ok(()),
+            Some(code) => Err(Self::new(code)),
+            #[cfg(unix)]
+            None => Err(Self::interrupt(
+                std::os::unix::prelude::ExitStatusExt::signal(&exit)
+                    .expect("program terminated with no exit code, nor interrupt signal"),
+            )),
+            _ => unreachable!("program terminated with no exit code"),
+        }
+    }
+}
+
+impl From<proc::ExitStatus> for CommandError {
+    fn from(exit: proc::ExitStatus) -> Self {
+        Self::from_exit(exit).expect_err("not an error")
+    }
+}
+
+impl Debug for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut result = f.debug_struct(match self {
+            CommandError::ExitError { .. } => "CommandError::ExitError",
+            CommandError::Interrupted { .. } => "CommandError::Interrupted",
+            CommandError::BadArgument { .. } => "CommandError::BadArgument",
+        });
+        match self {
+            CommandError::ExitError { program, code } => {
+                result.field("program", program);
+                result.field("code", code);
+            }
+            CommandError::Interrupted { program, interrupt } => {
+                result.field("program", program);
+                result.field("interrupt", interrupt);
+            }
+            CommandError::BadArgument {
+                program,
+                argument,
+                expect_found,
+                reason,
+            } => {
+                result.field("program", program);
+                result.field("argument", argument);
+                if let Some((expected, found)) = expect_found {
+                    result.field("expected", expected);
+                    result.field("found", &found.as_ref().to_string());
+                } else if let Some(reason) = reason {
+                    result.field("reason", reason);
+                }
+            }
+        }
+        result.finish()
+    }
+}
+
+impl Display for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommandError::ExitError { program, code } => {
+                write!(
+                    f,
+                    "{} exited with code #{}",
+                    program.unwrap_or("process"),
+                    code
+                )
+            }
+            CommandError::Interrupted { program, interrupt } => {
+                write!(
+                    f,
+                    "{} interrupted (signal: {})",
+                    program.unwrap_or("process"),
+                    interrupt
+                )
+            }
+            CommandError::BadArgument {
+                program,
+                argument,
+                expect_found,
+                reason,
+            } => {
+                let detail = if let Some((expected, found)) = expect_found {
+                    format!(" {expected} expected, but found {found}")
+                } else if let Some(why) = reason {
+                    format!(": {why}")
+                } else {
+                    "".to_string()
+                };
+                write!(
+                    f,
+                    "{} called with bad '{argument}' argument{detail}",
+                    program.unwrap_or("process")
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for CommandError {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
+        match self {
+            CommandError::BadArgument {
+                reason: Some(reason),
+                ..
+            } => Some(reason.as_ref()),
+            _ => None,
+        }
+    }
+}

--- a/xtask/state
+++ b/xtask/state
@@ -1,0 +1,6 @@
+WORK_DIR=./target
+TYPST_PKG=./typst-package
+PLUGIN_WASM=zint_typst_plugin.wasm
+PLUGIN_STUB_WASM=zint_typst_plugin_stub.wasm
+PLUGIN_STUB_OPT_WASM=zint_typst_plugin_stub_opt.wasm
+PLUGIN_WASM_OUT=zint_typst_plugin.wasm

--- a/zint-typst-plugin/.cargo/config.toml
+++ b/zint-typst-plugin/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasip1"

--- a/zint-typst-plugin/Cargo.toml
+++ b/zint-typst-plugin/Cargo.toml
@@ -17,4 +17,4 @@ ciborium = "0.2.1"
 
 thiserror = "1.0"
 
-wasm-minimal-protocol = { git = "https://github.com/astrale-sharp/wasm-minimal-protocol" }
+wasm-minimal-protocol = { path = "./vendor/wasm-minimal-protocol/crates/macro" }

--- a/zint-wasm-sys/Cargo.toml
+++ b/zint-wasm-sys/Cargo.toml
@@ -6,6 +6,9 @@ description = "Rust bindings for Wasm build of zint"
 license = "MIT"
 categories = ["external-ffi-bindings"]
 
+[target.'cfg(any(unix, target_os = "windows"))'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 cc = "1.0"
 bindgen = "0.70.1"

--- a/zint-wasm-sys/src/lib.rs
+++ b/zint-wasm-sys/src/lib.rs
@@ -5,7 +5,7 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(test)]
+#[cfg(all(test, any(unix, target_os = "windows")))]
 mod tests {
     use super::*;
     use libc::strlen;


### PR DESCRIPTION
This is intended to be a supplement for building the project and updating the typst package.

## What's xtask?
See [`xtask`](https://github.com/matklad/cargo-xtask).

In summary, it replaces the current `./build.sh` file with something that will make building the project completely reproducible. It's a tailor made build system for this project.

## Why so big?
It would be half the size if it used a bunch of existing crates to handle requests, extraction, etc.

But, when you run `cargo xtask package`, you don't want to wait 5min for the `xtask` to build just so you can build the package. So this relies on system tools like `wget`, `tar`, etc.

## Why in rust?
Because building the package already requires `cargo` to be installed. It would be much harder to write and test good shell script that covers all the cases `xtask` does.