### PR TITLE
Use debug build for xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-xtask = "run --package xtask --release --"
+xtask = "run --package xtask --"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -37,7 +37,7 @@ prefixed with `XTASK_` (`XTASK_<OPTION>`).
   - `TYPST_VERSION`: typst version used to compile the manual
 - Paths:
   - `WORK_DIR`: path to the output directory
-  - `TYPST_PKG`: path to the output directory
+  - `TYPST_PKG`: path to the typst package directory
   - `WASM_MIN_PROTOCOL_DIR`: path to `wasm-minimal-protocol` project used to compile `wasi-stub`
 
 A bunch of other, unlisted, variables are also defined/used, but they're


### PR DESCRIPTION
Building a debug build is faster, and performance cost will be low as xtask mostly runs external tools. Only file hashing is computationally expensive and it's barely noticeable atm.

I knew I'd create a followup PR within less than a day. :laughing: